### PR TITLE
feat(fe): hide button when dice animates, move player after dice animation

### DIFF
--- a/components/board/juru-board.tsx
+++ b/components/board/juru-board.tsx
@@ -31,19 +31,18 @@ export default function JuruBoard({ numOfPlayers }: { numOfPlayers: number }) {
     const roll = Math.floor(Math.random() * 6) + 1;
     setDiceRoll(roll);
 
-    setPlayers((prevPlayers) =>
-      prevPlayers.map((player) => {
-        if (player.id === currentPlayer) {
-          return {
-            ...player,
-            position: (player.position + roll) % 36,
-          };
-        }
-        return player;
-      })
-    );
-
     setTimeout(() => {
+      setPlayers((prevPlayers) =>
+        prevPlayers.map((player) => {
+          if (player.id === currentPlayer) {
+            return {
+              ...player,
+              position: (player.position + roll) % 36,
+            };
+          }
+          return player;
+        })
+      );
       setCurrentPlayer((prevPlayer) => (prevPlayer + 1) % numOfPlayers);
       setIsButtonDisabled(false);
       setShowDiceAnimation(false); // Stop showing the animation
@@ -118,25 +117,26 @@ export default function JuruBoard({ numOfPlayers }: { numOfPlayers: number }) {
 
       {/* Center */}
       <div className="col-span-10 row-span-6 bg-white flex flex-col justify-center items-center">
-        <button
-          onClick={handleRollDice}
-          disabled={isButtonDisabled}
-          className={`p-2 text-white rounded ${
-            isButtonDisabled
-              ? "cursor-not-allowed bg-gray-500"
-              : "cursor-pointer bg-blue-700"
-          }`}
-        >
-          <div>Player {currentPlayer + 1}</div>
-          Roll Dice (Roll: {diceRoll})
-        </button>
-        {showDiceAnimation && (
+        {showDiceAnimation ? (
           <div className="dice-animation">
             {/* Add your dice animation element here. For example, a simple div or an image */}
             <div className="w-10 h-10 bg-gray-400 rounded-full flex justify-center items-center">
               Rolling...
             </div>
           </div>
+        ) : (
+          <button
+            onClick={handleRollDice}
+            disabled={isButtonDisabled}
+            className={`p-2 text-white rounded ${
+              isButtonDisabled
+                ? "cursor-not-allowed bg-gray-500"
+                : "cursor-pointer bg-blue-700"
+            }`}
+          >
+            <div>Player {currentPlayer + 1}</div>
+            Roll Dice (Roll: {diceRoll})
+          </button>
         )}
       </div>
 


### PR DESCRIPTION
# **Name of PR**
hide button when dice animates, move player after dice animation

https://github.com/aptheparker/juru/assets/97675977/d56c43f5-3576-42cf-b1da-7e6e33db5809


<!-- This PR fixes #NUMBER_OF_THE_ISSUE, and fixes #NUMBER_OF_THE_ISSUE -->

## **Description**

<!--  📛📛
Please include a summary of the change and/or which issue is fixed.
List any dependencies required for this change, if there are any.
📛📛 -->

* Hide button when it shows dice animation
* Move player after dice animation is finished

---

### **Additional context**

<!-- Add any other context or additional information about the pull request.-->

*

<!-- 📛📛📛📛
If it fixes any current issue please let us know this way:
Uncomment the comment above "description", then add your number of issues after the "#".
Example: # **This pull request fixes #NUMBER_OF_THE_ISSUE issue**
If there are multiple issues to be closed with the merge of this pull request
please do it like so: **This pull request fixes #NUMBER_OF_THE_ISSUE, fixes #NUMBER_OF_THE_ISSUE and fixes #NUMBER_OF_THE_ISSUE issue**.
For more information on closing issues using keywords, please check https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords#closing-multiple-issues
📛📛📛📛 -->