### PR TITLE
feat: roll dice button content separated & useless comments deleted

### DIFF
--- a/components/board/juru-board.tsx
+++ b/components/board/juru-board.tsx
@@ -17,7 +17,7 @@ export default function JuruBoard({ numOfPlayers }: { numOfPlayers: number }) {
     Array.from({ length: num }, (_, index) => ({
       id: index,
       position: 0,
-      color: playerColors[index], // Assign a color to each player
+      color: playerColors[index],
     }));
   const [players, setPlayers] = useState(() => initializePlayers(numOfPlayers));
 
@@ -27,7 +27,7 @@ export default function JuruBoard({ numOfPlayers }: { numOfPlayers: number }) {
 
   const handleRollDice = () => {
     setIsButtonDisabled(true);
-    setShowDiceAnimation(true); // Start showing the animation
+    setShowDiceAnimation(true);
     const roll = Math.floor(Math.random() * 6) + 1;
     setDiceRoll(roll);
 
@@ -119,24 +119,26 @@ export default function JuruBoard({ numOfPlayers }: { numOfPlayers: number }) {
       <div className="col-span-10 row-span-6 bg-white flex flex-col justify-center items-center">
         {showDiceAnimation ? (
           <div className="dice-animation">
-            {/* Add your dice animation element here. For example, a simple div or an image */}
             <div className="w-10 h-10 bg-gray-400 rounded-full flex justify-center items-center">
               Rolling...
             </div>
           </div>
         ) : (
-          <button
-            onClick={handleRollDice}
-            disabled={isButtonDisabled}
-            className={`p-2 text-white rounded ${
-              isButtonDisabled
-                ? "cursor-not-allowed bg-gray-500"
-                : "cursor-pointer bg-blue-700"
-            }`}
-          >
-            <div>Player {currentPlayer + 1}</div>
-            Roll Dice (Roll: {diceRoll})
-          </button>
+          <div>
+            <div className="text-3xl font-bold mb-4">Dice Roll: {diceRoll}</div>
+            <button
+              onClick={handleRollDice}
+              disabled={isButtonDisabled}
+              className={`p-2 text-white rounded ${
+                isButtonDisabled
+                  ? "cursor-not-allowed bg-gray-500"
+                  : "cursor-pointer bg-blue-700"
+              }`}
+            >
+              <div>Player {currentPlayer + 1}</div>
+              Roll Dice
+            </button>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
# **Name of PR**

<!-- This PR fixes #NUMBER_OF_THE_ISSUE, and fixes #NUMBER_OF_THE_ISSUE -->

## **Description**

<!--  📛📛
Please include a summary of the change and/or which issue is fixed.
List any dependencies required for this change, if there are any.
📛📛 -->

<img width="1470" alt="image" src="https://github.com/aptheparker/juru/assets/98729115/dc7b9c20-a0b6-4591-b88d-f6f7a21b50be">

* The previous button is divided into two parts: button only & dice roll result.
---

### **Additional context**

<!-- Add any other context or additional information about the pull request.-->

* the design is not considered yet.

<!-- 📛📛📛📛
If it fixes any current issue please let us know this way:
Uncomment the comment above "description", then add your number of issues after the "#".
Example: # **This pull request fixes #NUMBER_OF_THE_ISSUE issue**
If there are multiple issues to be closed with the merge of this pull request
please do it like so: **This pull request fixes #NUMBER_OF_THE_ISSUE, fixes #NUMBER_OF_THE_ISSUE and fixes #NUMBER_OF_THE_ISSUE issue**.
For more information on closing issues using keywords, please check https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords#closing-multiple-issues
📛📛📛📛 -->

Closes #8